### PR TITLE
ci: chain publish.yml after tag-and-release; fix BCR metadata repo slug

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/filmil/bazel_graphviz_foreign",
+  "homepage": "https://github.com/filmil/bazel_graphviz",
   "maintainers": [
     {
       "name": "Filip Filmar",
@@ -9,7 +9,7 @@
     }
   ],
   "repository": [
-    "github:filmil/bazel_graphviz_foreign"
+    "github:filmil/bazel_graphviz"
   ],
   "versions": [
   ],

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ jobs:
       # This is the fork of `registry`. It can be the same repo.
       registry_fork: filmil/bazel-registry
       attest: false
+      # Personal registry has the same actor as both PR author and
+      # approver, so no draft-then-mark-ready dance is needed.
+      draft: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.15.0
@@ -51,3 +53,14 @@ jobs:
           allowUpdates: true
           artifacts: "${{ env.REPO_NAME }}-${{ env.VERSION }}.zip"
 
+  publish:
+    needs: tag
+    if: needs.tag.outputs.new_tag != ''
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ needs.tag.outputs.new_tag }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets: inherit


### PR DESCRIPTION
## Summary

- `tag-and-release.yml` now chains `publish.yml` automatically. The `tag`
  job exports the new tag as a job output, and a new `publish` job
  (guarded by \`if: needs.tag.outputs.new_tag != ''\`) reuses
  \`./.github/workflows/publish.yml\` to push a PR to the personal Bazel
  registry. Scheduled and \`workflow_dispatch\` runs both go end-to-end.
- \`publish.yml\` sets \`draft: false\`. Author and approver are the
  same actor on the personal registry, so the BCR draft-then-mark-ready
  workaround is unnecessary and only slows things down.
- \`.bcr/metadata.template.json\` updates the repository slug from the
  old \`bazel_graphviz_foreign\` name to \`bazel_graphviz\`. Without
  this, BCR validation rejects releases:
  \`The source URL of graphviz@0.0.38 ... doesn't match any of the
  module's source repositories ['github:filmil/bazel_graphviz_foreign']\`.

## Test plan

- [ ] On the next merge to \`main\`, a manual \`workflow_dispatch\` of
      Tag and Release should: bump a tag, create a GitHub release,
      upload the source zip, and then auto-trigger the registry-publish
      job for that tag.
- [ ] BCR validation for the next release should accept the source URL
      now that the repository slug matches.

Generated with [Claude Code](https://claude.com/claude-code)